### PR TITLE
Two Fixes. Er, One Fix now...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,4 +80,37 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.github</groupId>
+                        <artifactId>downloads-maven-plugin</artifactId>
+                        <version>0.4</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>upload</goal>
+                                </goals>
+                                <phase>deploy</phase>
+                            </execution>
+                        </executions>
+                        <!--
+                          This requires proper GitHub configuration in
+                          your ~/.m2/settings.xml file. See the plugin
+                          documentation for more information.
+                        -->
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
1. <del>Add my release repository as a remote since someone without it already in their local repo will get a failure when it searches central.</del>
2. Use the GitHub downloads plugin to upload the `.jar` artifact to the project when releasing a new version. I tested this as best I could. You'll need to following in your `~/.m2/settings.xml` if you don't already have it:
   
   ``` xml
   <profiles>
       <profile>
           <id>github</id>
           <properties>
               <github.global.userName>rtyley</github.global.userName>
               <github.global.password>rainbow sprinkles!!!!</github.global.password>
           </properties>
       </profile>
   </profiles>
   <activeProfiles>
       <activeProfile>github</activeProfile>
   </activeProfiles>
   ```
   
   Replace with your real password. Assuming I didn't just guess it exactly...
