### PR TITLE
Fix incompatibility with RoboGuice 2.0

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- only used by robolectric -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      package="com.github.rtyley.android.sherlock.roboguice"
+      android:versionCode="1"
+      android:versionName="1.0">
+
+    <application android:icon="@drawable/icon" android:label="@string/app_name" >
+    </application>
+    <uses-sdk android:minSdkVersion="3" />
+
+</manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.roboguice</groupId>
             <artifactId>roboguice</artifactId>
-            <version>2.0b4</version>
+            <version>2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>android.support</groupId>
@@ -62,9 +62,23 @@
         <dependency>
             <groupId>com.actionbarsherlock</groupId>
             <artifactId>library</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.1</version>
             <type>jar</type>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Test suite dependencies -->
+        <dependency>
+            <groupId>com.pivotallabs</groupId>
+            <artifactId>robolectric</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockAccountAuthenticatorActivity.java
+++ b/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockAccountAuthenticatorActivity.java
@@ -23,6 +23,7 @@ import roboguice.activity.event.*;
 import roboguice.event.EventManager;
 import roboguice.inject.ContentViewListener;
 import roboguice.inject.RoboInjector;
+import roboguice.util.RoboContext;
 
 import android.accounts.AccountAuthenticatorActivity;
 import android.content.Intent;
@@ -30,6 +31,10 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 
 import com.google.inject.Inject;
+import com.google.inject.Key;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A subclass of {@link AccountAuthenticatorActivity} that provides dependency injection
@@ -37,8 +42,9 @@ import com.google.inject.Inject;
  *
  * @author Marcus Better
  */
-public class RoboSherlockAccountAuthenticatorActivity extends SherlockAccountAuthenticatorActivity {
+public class RoboSherlockAccountAuthenticatorActivity extends SherlockAccountAuthenticatorActivity implements RoboContext {
     protected EventManager eventManager;
+    protected HashMap<Key<?>, Object> scopedObjects = new HashMap<Key<?>, Object>();
 
     @Inject ContentViewListener ignored; // BUG find a better place to put this
 
@@ -121,5 +127,10 @@ public class RoboSherlockAccountAuthenticatorActivity extends SherlockAccountAut
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         eventManager.fire(new OnActivityResultEvent(requestCode, resultCode, data));
+    }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
     }
 }

--- a/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockActivity.java
+++ b/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockActivity.java
@@ -21,6 +21,7 @@ import android.os.Bundle;
 
 import com.actionbarsherlock.app.SherlockActivity;
 import com.google.inject.Inject;
+import com.google.inject.Key;
 
 import roboguice.RoboGuice;
 import roboguice.activity.event.OnActivityResultEvent;
@@ -37,13 +38,18 @@ import roboguice.activity.event.OnStopEvent;
 import roboguice.event.EventManager;
 import roboguice.inject.ContentViewListener;
 import roboguice.inject.RoboInjector;
+import roboguice.util.RoboContext;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * An example of how to make your own Robo-enabled Sherlock activity. Feel free
  * to do with with any of the other Sherlock activity types!
  */
-public class RoboSherlockActivity extends SherlockActivity {
+public class RoboSherlockActivity extends SherlockActivity implements RoboContext {
     protected EventManager eventManager;
+    protected HashMap<Key<?>,Object> scopedObjects = new HashMap<Key<?>,Object>();
 
     @Inject
     ContentViewListener ignored; // BUG find a better place to put this
@@ -127,5 +133,10 @@ public class RoboSherlockActivity extends SherlockActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         eventManager.fire(new OnActivityResultEvent(requestCode, resultCode, data));
+    }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
     }
 }

--- a/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockFragmentActivity.java
+++ b/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockFragmentActivity.java
@@ -5,19 +5,24 @@ import android.os.Bundle;
 import com.actionbarsherlock.app.SherlockFragmentActivity;
 
 import roboguice.RoboGuice;
-
 import roboguice.activity.event.*;
 import roboguice.event.EventManager;
 import roboguice.inject.ContentViewListener;
 import roboguice.inject.RoboInjector;
+import roboguice.util.RoboContext;
 
 import android.content.Intent;
 import android.content.res.Configuration;
 
 import com.google.inject.Inject;
+import com.google.inject.Key;
 
-public class RoboSherlockFragmentActivity extends SherlockFragmentActivity {
+import java.util.HashMap;
+import java.util.Map;
+
+public class RoboSherlockFragmentActivity extends SherlockFragmentActivity implements RoboContext {
     protected EventManager eventManager;
+    protected HashMap<Key<?>, Object> scopedObjects = new HashMap<Key<?>, Object>();
 
     @Inject ContentViewListener ignored; // BUG find a better place to put this
 
@@ -100,5 +105,10 @@ public class RoboSherlockFragmentActivity extends SherlockFragmentActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         eventManager.fire(new OnActivityResultEvent(requestCode, resultCode, data));
+    }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
     }
 }

--- a/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockListActivity.java
+++ b/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockListActivity.java
@@ -30,19 +30,25 @@ import roboguice.activity.event.OnStopEvent;
 import roboguice.event.EventManager;
 import roboguice.inject.ContentViewListener;
 import roboguice.inject.RoboInjector;
+import roboguice.util.RoboContext;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 
 import com.actionbarsherlock.app.SherlockListActivity;
 import com.google.inject.Inject;
+import com.google.inject.Key;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * An example of how to make your own Robo-enabled Sherlock activity. Feel free
  * to do with with any of the other Sherlock activity types!
  */
-public class RoboSherlockListActivity extends SherlockListActivity {
+public class RoboSherlockListActivity extends SherlockListActivity implements RoboContext {
     protected EventManager eventManager;
+    protected HashMap<Key<?>, Object> scopedObjects = new HashMap<Key<?>, Object>();
 
     @Inject
     ContentViewListener ignored; // BUG find a better place to put this
@@ -126,5 +132,10 @@ public class RoboSherlockListActivity extends SherlockListActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         eventManager.fire(new OnActivityResultEvent(requestCode, resultCode, data));
+    }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
     }
 }

--- a/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockPreferenceActivity.java
+++ b/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockPreferenceActivity.java
@@ -31,6 +31,7 @@ import roboguice.event.EventManager;
 import roboguice.inject.ContentViewListener;
 import roboguice.inject.PreferenceListener;
 import roboguice.inject.RoboInjector;
+import roboguice.util.RoboContext;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -38,14 +39,19 @@ import android.preference.PreferenceScreen;
 
 import com.actionbarsherlock.app.SherlockPreferenceActivity;
 import com.google.inject.Inject;
+import com.google.inject.Key;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * An example of how to make your own Robo-enabled Sherlock activity. Feel free
  * to do with with any of the other Sherlock activity types!
  */
-public class RoboSherlockPreferenceActivity extends SherlockPreferenceActivity {
+public class RoboSherlockPreferenceActivity extends SherlockPreferenceActivity implements RoboContext {
     protected EventManager eventManager;
     protected PreferenceListener preferenceListener;
+    protected HashMap<Key<?>, Object> scopedObjects = new HashMap<Key<?>, Object>();
 
     @Inject
     ContentViewListener ignored; // BUG find a better place to put this
@@ -136,5 +142,10 @@ public class RoboSherlockPreferenceActivity extends SherlockPreferenceActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         eventManager.fire(new OnActivityResultEvent(requestCode, resultCode, data));
+    }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
     }
 }

--- a/src/test/java/com/github/rtyley/android/sherlock/roboguice/R.java
+++ b/src/test/java/com/github/rtyley/android/sherlock/roboguice/R.java
@@ -1,0 +1,7 @@
+package com.github.rtyley.android.sherlock.roboguice;
+
+/**
+ * Used by robolectric
+ */
+public class R {
+}

--- a/src/test/java/com/github/rtyley/android/sherlock/roboguice/activity/SherlockActivityInjectionTest.java
+++ b/src/test/java/com/github/rtyley/android/sherlock/roboguice/activity/SherlockActivityInjectionTest.java
@@ -1,0 +1,325 @@
+package com.github.rtyley.android.sherlock.roboguice.activity;
+
+import android.R;
+import android.app.Activity;
+import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import com.actionbarsherlock.ActionBarSherlock;
+import com.actionbarsherlock.internal.ActionBarSherlockNative;
+import com.github.rtyley.android.sherlock.roboguice.activity.SherlockActivityInjectionTest.ModuleA.A;
+import com.github.rtyley.android.sherlock.roboguice.activity.SherlockActivityInjectionTest.ModuleB.B;
+import com.github.rtyley.android.sherlock.roboguice.activity.SherlockActivityInjectionTest.ModuleC.C;
+import com.github.rtyley.android.sherlock.roboguice.activity.SherlockActivityInjectionTest.ModuleD.D;
+import com.google.inject.*;
+import com.xtremelabs.robolectric.Robolectric;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import roboguice.RoboGuice;
+import roboguice.inject.*;
+import roboguice.test.RobolectricRoboTestRunner;
+
+import java.lang.ref.SoftReference;
+import java.util.ArrayList;
+import java.util.concurrent.*;
+
+import static com.xtremelabs.robolectric.Robolectric.shadowOf;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(RobolectricRoboTestRunner.class)
+public class SherlockActivityInjectionTest {
+
+    protected DummySherlockActivity activity;
+
+    @Before
+    public void setup() {
+        RoboGuice.setBaseApplicationInjector(Robolectric.application, Stage.DEVELOPMENT, RoboGuice.newDefaultRoboModule(Robolectric.application), new ModuleA());
+        ActionBarSherlock.registerImplementation(ActionBarSherlockRobolectric.class);
+        activity = new DummySherlockActivity();
+        activity.setIntent(new Intent(Robolectric.application, DummySherlockActivity.class).putExtra("foobar", "goober"));
+        activity.onCreate(null);
+    }
+
+    @Test
+    public void shouldInjectUsingDefaultConstructor() {
+        assertThat(activity.emptyString, is(""));
+    }
+
+    @Test
+    public void shouldInjectView() {
+        assertThat(activity.text1, is(activity.findViewById(R.id.text1)));
+    }
+
+    @Test
+    public void shouldInjectStringResource() {
+        assertThat(activity.cancel, is("Cancel"));
+    }
+
+    @Test
+    public void shouldInjectExtras() {
+        assertThat(activity.foobar, is("goober"));
+    }
+
+    @Test
+    public void shouldStaticallyInject() {
+        assertThat(A.t, equalTo(""));
+    }
+
+    @Test
+    public void shouldStaticallyInjectResources() {
+        assertThat(A.s, equalTo("Cancel"));
+    }
+
+    @Test
+    public void shouldInjectActivityAndRoboSherlockActivity() {
+        assertEquals(activity, activity.activity);
+        assertEquals(activity, activity.roboSherlockActivity);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void shouldNotStaticallyInjectViews() {
+        RoboGuice.setBaseApplicationInjector(Robolectric.application, Stage.DEVELOPMENT, RoboGuice.newDefaultRoboModule(Robolectric.application), new ModuleB());
+        final B b = new B();
+        b.onCreate(null);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void shouldNotStaticallyInjectExtras() {
+        RoboGuice.setBaseApplicationInjector(Robolectric.application, Stage.DEVELOPMENT, RoboGuice.newDefaultRoboModule(Robolectric.application), new ModuleD());
+        final D d = new D();
+        d.onCreate(null);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void shouldNotStaticallyInjectPreferenceViews() {
+        RoboGuice.setBaseApplicationInjector(Robolectric.application, Stage.DEVELOPMENT, RoboGuice.newDefaultRoboModule(Robolectric.application), new ModuleC());
+        final C c = new C();
+        c.onCreate(null);
+    }
+
+    @Test
+    public void shouldInjectApplication() {
+        final G g = new G();
+        g.onCreate(null);
+
+        assertThat(g.application, equalTo(Robolectric.application));
+    }
+
+    @Test
+    public void shouldAllowBackgroundThreadsToFinishUsingContextAfterOnDestroy() throws Exception {
+        final SoftReference<F> ref = new SoftReference<F>(new F());
+        ref.get().onCreate(null);
+
+        final BlockingQueue<Context> queue = new ArrayBlockingQueue<Context>(1);
+        new Thread() {
+            final Context context = RoboGuice.getInjector(ref.get()).getInstance(Context.class);
+
+            @Override
+            public void run() {
+                queue.add(context);
+            }
+        }.start();
+
+        ref.get().onDestroy();
+
+        // Force an OoM
+        // http://stackoverflow.com/questions/3785713/how-to-make-the-java-system-release-soft-references/3810234
+        try {
+            @SuppressWarnings({"MismatchedQueryAndUpdateOfCollection"}) final ArrayList<Object[]> allocations = new ArrayList<Object[]>();
+            //noinspection InfiniteLoopStatement
+            while (true) {
+                allocations.add(new Object[(int) Runtime.getRuntime().maxMemory()]);
+            }
+        } catch (OutOfMemoryError e) {
+            // Yeah!
+        }
+
+        assertNotNull(queue.poll(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void shouldBeAbleToGetContextProvidersInBackgroundThreads() throws Exception {
+        final F f = new F();
+        f.onCreate(null);
+
+        final FutureTask<Context> future = new FutureTask<Context>(new Callable<Context>() {
+            final ContextScopedProvider<Context> contextProvider = RoboGuice.getInjector(f).getInstance(Key.get(new TypeLiteral<ContextScopedProvider<Context>>(){}));
+
+            @Override
+            public Context call() throws Exception {
+                return contextProvider.get(f);
+            }
+        });
+
+        Executors.newSingleThreadExecutor().execute(future);
+
+        future.get();
+    }
+
+    public static class DummySherlockActivity extends RoboSherlockActivity {
+        @Inject protected String emptyString;
+        @Inject protected Activity activity;
+        @Inject protected RoboSherlockActivity roboSherlockActivity;
+        @InjectView(R.id.text1) protected TextView text1;
+        @InjectResource(R.string.cancel) protected String cancel;
+        @InjectExtra("foobar") protected String foobar;
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+
+            final LinearLayout root = new LinearLayout(this);
+
+            final TextView text1 = new TextView(this);
+            root.addView(text1);
+            text1.setId(R.id.text1);
+
+            final LinearLayout included1 = addIncludedView(R.id.summary, R.string.ok);
+            root.addView(included1);
+            final LinearLayout included2 = addIncludedView(R.id.title, R.string.no);
+            root.addView(included2);
+
+            setContentView(root);
+        }
+
+        protected LinearLayout addIncludedView(int includedRootId, int stringResId) {
+            LinearLayout container = new LinearLayout(this);
+            container.setId(includedRootId);
+
+            TextView textView = new TextView(this);
+            container.addView(textView);
+            textView.setId(R.id.text2);
+            textView.setText(stringResId);
+            return container;
+        }
+    }
+
+    public static class BaseModule extends com.google.inject.AbstractModule {
+        @Override
+        protected void configure() {
+            bind(RoboSherlockActivity.class)
+                    .toProvider(Key.get(new TypeLiteral<NullProvider<RoboSherlockActivity>>(){}))
+                    .in(ContextSingleton.class);
+        }
+    }
+
+    public static class ModuleA extends BaseModule {
+        @Override
+        protected void configure() {
+            super.configure();
+            requestStaticInjection(A.class);
+        }
+
+        public static class A {
+            @InjectResource(R.string.cancel) static String s;
+            @Inject static String t;
+        }
+    }
+
+    public static class ModuleB extends BaseModule {
+        @Override
+        protected void configure() {
+            super.configure();
+            requestStaticInjection(B.class);
+        }
+
+        public static class B extends RoboSherlockActivity {
+            @InjectView(0) static View v;
+
+            @Override
+            protected void onCreate(Bundle savedInstanceState) {
+                super.onCreate(savedInstanceState);
+            }
+        }
+    }
+
+    public static class ModuleC extends BaseModule {
+        @Override
+        public void configure() {
+            super.configure();
+            requestStaticInjection(C.class);
+        }
+
+        public static class C extends RoboSherlockActivity {
+            @InjectPreference("xxx") static Preference v;
+
+            @Override
+            protected void onCreate(Bundle savedInstanceState) {
+                super.onCreate(savedInstanceState);
+            }
+        }
+    }
+
+    public static class ModuleD extends BaseModule {
+        @Override
+        public void configure() {
+            super.configure();
+            requestStaticInjection(D.class);
+        }
+
+        public static class D extends RoboSherlockActivity {
+            @InjectExtra("xxx") static String s;
+
+            @Override
+            protected void onCreate(Bundle savedInstanceState) {
+                super.onCreate(savedInstanceState);
+            }
+        }
+    }
+
+    public static class F extends RoboSherlockActivity {
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+        }
+
+        @Override
+        protected void onDestroy() {
+            super.onDestroy();
+        }
+    }
+
+    public static class PojoA {
+        @InjectView(100) View v;
+    }
+
+    public static class G extends RoboSherlockActivity {
+        @Inject Application application;
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+        }
+    }
+
+    @ActionBarSherlock.Implementation(api = 0)
+    public static class ActionBarSherlockRobolectric extends ActionBarSherlockNative {
+        public ActionBarSherlockRobolectric(Activity activity, int flags) {
+            super(activity, flags);
+        }
+
+        @Override
+        public void setContentView(int layoutResId) {
+            LayoutInflater layoutInflater = LayoutInflater.from(mActivity);
+            View contentView = layoutInflater.inflate(layoutResId, null);
+
+            shadowOf(mActivity).setContentView(contentView);
+        }
+
+        @Override
+        public void setContentView(View view) {
+            shadowOf(mActivity).setContentView(view);
+        }
+    }
+}


### PR DESCRIPTION
Due to stricter requirements in RoboGuice 2.0, all Activity subclasses must implement RoboContext.

This commit also adds a series of tests for `RoboSherlockActivity` modeled after the ones for `RoboActivity` in RoboGuice.
