### PR TITLE
Various fixes for test suite

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -9,6 +9,6 @@
 
     <application android:icon="@drawable/icon" android:label="@string/app_name" >
     </application>
-    <uses-sdk android:minSdkVersion="3" />
+    <uses-sdk android:minSdkVersion="7" />
 
 </manifest>

--- a/src/test/java/com/github/rtyley/android/sherlock/roboguice/activity/SherlockActivityInjectionTest.java
+++ b/src/test/java/com/github/rtyley/android/sherlock/roboguice/activity/SherlockActivityInjectionTest.java
@@ -290,10 +290,6 @@ public class SherlockActivityInjectionTest {
         }
     }
 
-    public static class PojoA {
-        @InjectView(100) View v;
-    }
-
     public static class G extends RoboSherlockActivity {
         @Inject Application application;
 


### PR DESCRIPTION
As pointed out by @zhen9ao in pull request #7, the current test suite requires Androd 1.5 SDK (API Level 3) to run successfully. I raised the required SDK to Android 2.1 (API Level 7), which is the minimum API Level supported by ActionBarSherlock itself.

Note that it's currently impossible to use a combination of `minSdkVersion` and `targetSdkVersion` to define a range of SDKs suitable for testing because Robolectric will try to use the latter (if defined) without falling back to the former or anything in-between.

Also, I removed an unused POJO in `SherlockActivityInjectionTest`.
