### PR TITLE
Add RoboSherlockAccountAuthenticatorFragmentActivity

### DIFF
--- a/src/main/java/com/github/rtyley/android/sherlock/android/accounts/SherlockAccountAuthenticatorFragmentActivity.java
+++ b/src/main/java/com/github/rtyley/android/sherlock/android/accounts/SherlockAccountAuthenticatorFragmentActivity.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.rtyley.android.sherlock.android.accounts;
+
+import android.accounts.AccountAuthenticatorResponse;
+import android.accounts.AccountManager;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
+
+/**
+ * Base class for implementing an Activity that is used to help implement an
+ * AbstractAccountAuthenticator. If the AbstractAccountAuthenticator needs to use an activity
+ * to handle the request then it can have the activity extend SherlockAccountAuthenticatorActivity.
+ * The AbstractAccountAuthenticator passes in the response to the intent using the following:
+ * <pre>
+ *      intent.putExtra({@link android.accounts.AccountManager#KEY_ACCOUNT_AUTHENTICATOR_RESPONSE}, response);
+ * </pre>
+ * The activity then sets the result that is to be handed to the response via
+ * {@link #setAccountAuthenticatorResult(android.os.Bundle)}.
+ * This result will be sent as the result of the request when the activity finishes. If this
+ * is never set or if it is set to null then error {@link android.accounts.AccountManager#ERROR_CODE_CANCELED}
+ * will be called on the response.
+ */
+public class SherlockAccountAuthenticatorFragmentActivity extends SherlockFragmentActivity {
+    private AccountAuthenticatorResponse mAccountAuthenticatorResponse = null;
+    private Bundle mResultBundle = null;
+
+    /**
+     * Set the result that is to be sent as the result of the request that caused this
+     * Activity to be launched. If result is null or this method is never called then
+     * the request will be canceled.
+     * @param result this is returned as the result of the AbstractAccountAuthenticator request
+     */
+    public final void setAccountAuthenticatorResult(Bundle result) {
+        mResultBundle = result;
+    }
+
+    /**
+     * Retreives the AccountAuthenticatorResponse from either the intent of the icicle, if the
+     * icicle is non-zero.
+     * @param icicle the save instance data of this Activity, may be null
+     */
+    protected void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+
+        mAccountAuthenticatorResponse =
+                getIntent().getParcelableExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE);
+
+        if (mAccountAuthenticatorResponse != null) {
+            mAccountAuthenticatorResponse.onRequestContinued();
+        }
+    }
+
+    /**
+     * Sends the result or a Constants.ERROR_CODE_CANCELED error if a result isn't present.
+     */
+    public void finish() {
+        if (mAccountAuthenticatorResponse != null) {
+            // send the result bundle back if set, otherwise send an error.
+            if (mResultBundle != null) {
+                mAccountAuthenticatorResponse.onResult(mResultBundle);
+            } else {
+                mAccountAuthenticatorResponse.onError(AccountManager.ERROR_CODE_CANCELED,
+                        "canceled");
+            }
+            mAccountAuthenticatorResponse = null;
+        }
+        super.finish();
+    }
+}

--- a/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockAccountAuthenticatorFragmentActivity.java
+++ b/src/main/java/com/github/rtyley/android/sherlock/roboguice/activity/RoboSherlockAccountAuthenticatorFragmentActivity.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2009 Michael Burton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+// derived from RoboActivity.java
+
+package com.github.rtyley.android.sherlock.roboguice.activity;
+
+import com.github.rtyley.android.sherlock.android.accounts.SherlockAccountAuthenticatorFragmentActivity;
+import roboguice.RoboGuice;
+import roboguice.activity.event.*;
+import roboguice.event.EventManager;
+import roboguice.inject.ContentViewListener;
+import roboguice.inject.RoboInjector;
+import roboguice.util.RoboContext;
+
+import android.accounts.AccountAuthenticatorActivity;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Bundle;
+
+import com.google.inject.Inject;
+import com.google.inject.Key;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A subclass of {@link AccountAuthenticatorActivity} that provides dependency injection
+ * with RoboGuice.
+ *
+ * @author Marcus Better
+ */
+public class RoboSherlockAccountAuthenticatorFragmentActivity extends SherlockAccountAuthenticatorFragmentActivity implements RoboContext {
+    protected EventManager eventManager;
+    protected HashMap<Key<?>, Object> scopedObjects = new HashMap<Key<?>, Object>();
+
+    @Inject ContentViewListener ignored; // BUG find a better place to put this
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        final RoboInjector injector = RoboGuice.getInjector(this);
+        eventManager = injector.getInstance(EventManager.class);
+        injector.injectMembersWithoutViews(this);
+        super.onCreate(savedInstanceState);
+        eventManager.fire(new OnCreateEvent(savedInstanceState));
+    }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        eventManager.fire(new OnRestartEvent());
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent());
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent());
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent());
+    }
+
+    @Override
+    protected void onNewIntent( Intent intent ) {
+        super.onNewIntent(intent);
+        eventManager.fire(new OnNewIntentEvent());
+    }
+
+    @Override
+    protected void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent());
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent());
+        } finally {
+            try {
+                RoboGuice.destroyInjector(this);
+            } finally {
+                super.onDestroy();
+            }
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(currentConfig, newConfig));
+    }
+
+    @Override
+    public void onContentChanged() {
+        super.onContentChanged();
+        RoboGuice.getInjector(this).injectViewMembers(this);
+        eventManager.fire(new OnContentChangedEvent());
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        eventManager.fire(new OnActivityResultEvent(requestCode, resultCode, data));
+    }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
+    }
+}


### PR DESCRIPTION
Primarily this allows us to use getSupportFragmentManager() to support using fragments in subclasses.

This could/should be done for all RoboSherlock*Activities, but alas I am lazy.
